### PR TITLE
Adds getPermissions override logic for generating missing permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 .classpath
 .project
 .settings
+# Intellij
+*.iml
+*.idea

--- a/src/main/java/net/sourceforge/prograde/policy/SecurityActions.java
+++ b/src/main/java/net/sourceforge/prograde/policy/SecurityActions.java
@@ -28,7 +28,7 @@ import java.security.Security;
  * 
  * @author Josef Cacek
  */
-class SecurityActions {
+public class SecurityActions {
 
     /**
      * Returns a system property value using the specified <code>key</code>.
@@ -36,7 +36,7 @@ class SecurityActions {
      * @param key
      * @return
      */
-    static String getSystemProperty(final String key) {
+    public static String getSystemProperty(final String key) {
         final SecurityManager sm = System.getSecurityManager();
 
         if (sm != null) {
@@ -57,7 +57,7 @@ class SecurityActions {
      * @see Security#getProperty(String)
      * @return
      */
-    static String getSecurityProperty(final String key) {
+    public static String getSecurityProperty(final String key) {
         final SecurityManager sm = System.getSecurityManager();
 
         if (sm != null) {


### PR DESCRIPTION
Carries forward the work from [this commit](https://github.com/codice/pro-grade/commit/76b65f0e18d85ea0efa95f7f3503bb83a8f5bfd5).

Uses the override property added in (76b65f0e18d85ea0efa95f7f3503bb83a8f5bfd5) in the same
manner as it was used in ProGradePolicy.

Added override property for getPermissions call to return an empty permissions object instead of the read only permission list

Allows you to get around some known bugs in other libraries and the JDK, such as:

JDK bug JDK-8014008 https://bugs.openjdk.java.net/browse/JDK-8014008
Jasper bug https://bz.apache.org/bugzilla/show_bug.cgi?id=41509

Overrides can be added for these classes/methods as long as they are known to be safe.